### PR TITLE
add two new line after import statement & change input.txt

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -7,7 +7,9 @@
 			"$BLOCK_COMMENT_END",
 			"",
 			"import sys",
-			"sys.stdin = open('${2:${TM_FILENAME/(.*)\\..+$/$1/}_input}.txt')",
+			"${newline}",
+			"${newline}",
+			"sys.stdin = open('input_${2:${TM_FILENAME/(.*)\\..+$/$1/}}.txt')",
 			"",
 			"${0}"
 		],


### PR DESCRIPTION
1. Two blank lines between the import statements and other code.
https://www.python.org/dev/peps/pep-0008/#blank-lines

2. change `input.txt` name
`9898_input.txt` -> `input_9898.txt`